### PR TITLE
fix: implement missing method

### DIFF
--- a/ios/CollectorManager.swift
+++ b/ios/CollectorManager.swift
@@ -65,4 +65,8 @@ class CollectorManager: NSObject {
             }
         }
     }
+    @objc
+    static func requiresMainQueueSetup() -> Bool {
+        return true
+    }
 }

--- a/ios/VgsCollectReactNativeViewManager.swift
+++ b/ios/VgsCollectReactNativeViewManager.swift
@@ -7,6 +7,10 @@ class VgsCollectReactNativeViewManager: RCTViewManager {
   override func view() -> (VgsCollectReactNativeView) {
     return VgsCollectReactNativeView()
   }
+
+  override class func requiresMainQueueSetup() -> Bool {
+    return true
+  }
 } 
 
 class VgsCollectReactNativeView : UIView {


### PR DESCRIPTION
Suppress RN warnings by implementing missing `requiresMainQueueSetup` method.

https://app.asana.com/0/1204416704606806/1204323441804506/f https://app.asana.com/0/1204416704606806/1204323441804505/f